### PR TITLE
WIP: Add mutual authentication mode with key exchange

### DIFF
--- a/index.js
+++ b/index.js
@@ -287,7 +287,7 @@ Protocol.prototype._guessRole = function () {
 }
 
 Protocol.prototype._startEncryption = function () {
-  console.log("\nSTART ENCRYPTION?\n")
+  console.log('\nSTART ENCRYPTION?\n')
   // Make sure we have the key and nonce
   if (!this.key || !this._nonce) return
 

--- a/schema.proto
+++ b/schema.proto
@@ -5,6 +5,9 @@
 message Feed {
   required bytes discoveryKey = 1;
   optional bytes nonce = 2;
+  // If a client wishes to authenticate, it sends it's public key to the server
+  // (sent as sealed box using server's public key)
+  optional bytes identity = 4;
 }
 
 // type=1, overall connection handshake. should be send just after the feed message on the first channel only


### PR DESCRIPTION
The goal of this PR is to add a client-server mode with client authentication and a more secure encryption key using the libsodium key exchange function.

At the protocol level, the changes are very minimal.  The `Feed` message type now has an optional `identity` field along with the existing `nonce` field.  This `identity` field is the client's public key, but encrypted in a sealed box addressed to the server's public key.  The purpose of the sealed box is so that fake servers will be unable to read anything.

Once both sides know the other side's supposed public key, it's put to the test by encrypting the stream with a shared key that can only be derived by knowing both public keys and one of the private keys.  This new encryption key is more secure than the normal model as it makes each client/server pair have a unique key.

The new API is to simply pass in your public and private key as part of the `Protocol` constructor as seen in the following example:

```js
const protocol = require('./hypercore-protocol')

const {
  crypto_kx_keypair,
  crypto_kx_PUBLICKEYBYTES,
  crypto_kx_SECRETKEYBYTES
} = require('./sodium-native')

let serverId = {
  pk: Buffer.alloc(crypto_kx_PUBLICKEYBYTES),
  sk: Buffer.alloc(crypto_kx_SECRETKEYBYTES)
}
crypto_kx_keypair(serverId.pk, serverId.sk)

let clientId = {
  pk: Buffer.alloc(crypto_kx_PUBLICKEYBYTES),
  sk: Buffer.alloc(crypto_kx_SECRETKEYBYTES)
}
crypto_kx_keypair(clientId.pk, clientId.sk)

// console.log(crypto_kx_keypair)
let serverStream = protocol({
  authenticate: serverId
})

let clientStream = protocol({
  authenticate: clientId
})
```

The feed/channel then proceeds as normal using the server's public key as the hypercore key.

```js
let server = serverStream.feed(serverId.pk)
let client = clientStream.feed(serverId.pk)
```