### PR TITLE
Ensure that extensions are sorted

### DIFF
--- a/index.js
+++ b/index.js
@@ -33,6 +33,7 @@ function Protocol (opts) {
   this.feeds = []
   this.expectedFeeds = opts.expectedFeeds || 0
   this.extensions = opts.extensions || []
+  this.extensions.sort() // sort for sorted-indexof calls
   this.remoteExtensions = null
 
   this._localFeeds = []


### PR DESCRIPTION
This is necessary for the sorted-indexof calls