### PR TITLE
Unencrypted streams should not check first key

### DIFF
--- a/index.js
+++ b/index.js
@@ -437,6 +437,7 @@ Protocol.prototype._parseLength = function (data, start) {
 }
 
 Protocol.prototype._sameKey = function () {
+  if (!this.encrypted) return true
   if (!this.discoveryKey || !this.remoteDiscoveryKey) return true
   if (this.remoteDiscoveryKey.toString('hex') === this.discoveryKey.toString('hex')) return true
   this.destroy(new Error('First shared hypercore must be the same'))

--- a/test.js
+++ b/test.js
@@ -542,3 +542,22 @@ tape('extension message', function (t) {
 
   a.pipe(b).pipe(a)
 })
+
+tape.only('encrypt: false should ignore the first key', function (t) {
+  t.plan(1)
+
+  var a = protocol({ encrypt: false })
+  var b = protocol({ encrypt: false })
+
+  var ch1 = a.feed(KEY)
+  b.feed(OTHER_KEY)
+  var ch3 = b.feed(KEY)
+
+  ch1.on('data', function (data) {
+    t.same(data, {index: 42, signature: null, value: bufferFrom('hi'), nodes: []})
+  })
+
+  ch3.data({index: 42, value: bufferFrom('hi')})
+
+  a.pipe(b).pipe(a)
+})

--- a/test.js
+++ b/test.js
@@ -543,7 +543,7 @@ tape('extension message', function (t) {
   a.pipe(b).pipe(a)
 })
 
-tape.only('encrypt: false should ignore the first key', function (t) {
+tape('encrypt: false should ignore the first key', function (t) {
   t.plan(1)
 
   var a = protocol({ encrypt: false })
@@ -551,13 +551,13 @@ tape.only('encrypt: false should ignore the first key', function (t) {
 
   var ch1 = a.feed(KEY)
   b.feed(OTHER_KEY)
-  var ch3 = b.feed(KEY)
+  var ch2 = b.feed(KEY)
 
   ch1.on('data', function (data) {
     t.same(data, {index: 42, signature: null, value: bufferFrom('hi'), nodes: []})
   })
 
-  ch3.data({index: 42, value: bufferFrom('hi')})
+  ch2.data({index: 42, value: bufferFrom('hi')})
 
   a.pipe(b).pipe(a)
 })


### PR DESCRIPTION
When `encrypt: false`, two protocol streams should be able to exchange data even if their first feeds are different.

This PR prevents this scenario from throwing an error, and adds a small test.