### PR TITLE
Add onchannelclose handler + test + docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,8 @@ Options include:
   keyPair: { publicKey, secretKey }, // use this keypair for the stream authentication
   onauthenticate (remotePublicKey, done) { }, // hook to verify the remotes public key
   onhandshake () { }, // function called when the stream handshake has finished
-  ondiscoverykey (discoveryKey) { } // function called when the remote stream opens a feed you have not
+  ondiscoverykey (discoveryKey) { }, // function called when the remote stream opens a feed you have not
+  onchannelclose (discoveryKey, publicKey) { } // function called when a feed-channel closes
 }
 ```
 

--- a/index.js
+++ b/index.js
@@ -144,6 +144,10 @@ class Channelizer {
       ch.handlers.onclose()
     }
 
+    if (this.stream.handlers && this.stream.handlers.onchannelclose) {
+      this.stream.handlers.onchannelclose(ch.discoveryKey, ch.key)
+    }
+
     if (ch.localId > -1) {
       this.local[ch.localId] = null
     }
@@ -167,6 +171,10 @@ class Channelizer {
     for (const ch of this.created.values()) {
       ch.localId = ch.remoteId = -1
       if (ch.handlers && ch.handlers.onclose) ch.handlers.onclose()
+
+      if (this.stream.handlers && this.stream.handlers.onchannelclose) {
+        this.stream.handlers.onchannelclose(ch.discoveryKey, ch.key)
+      }
     }
     this.created.clear()
   }

--- a/test.js
+++ b/test.js
@@ -450,3 +450,40 @@ tape('can close by discovery key', function (t) {
     t.end()
   })
 })
+
+tape('onchannelclose handler', function (t) {
+  t.plan(9)
+  let dk = null
+  let expectedCalls = 2
+  const a = new Protocol(true, {
+    onchannelclose (discoveryKey, key) {
+      t.pass('A triggered onchannelclose')
+      t.ok(discoveryKey.equals(dk), 'discoveryKey was passed')
+      t.ok(key, 'publicKey was passed')
+      if (!--expectedCalls) t.end()
+    }
+  })
+  const b = new Protocol(false, {
+    ondiscoverykey (discoveryKey) {
+      t.pass('triggered ondiscoverykey')
+      dk = discoveryKey
+      b.close(discoveryKey)
+    },
+    onchannelclose (discoveryKey, key) {
+      t.pass('B triggered onchannelclose')
+      t.ok(discoveryKey.equals(dk), 'discoveryKey always available')
+      t.equal(key, null, 'publicKey null when channel wasn\'t established on both ends')
+      if (!--expectedCalls) t.end()
+    }
+  })
+
+  a.open(KEY, {
+    onclose () {
+      t.pass('channel closed')
+    }
+  })
+
+  a.pipe(b).pipe(a).on('end', function () {
+    t.pass('stream ended')
+  })
+})


### PR DESCRIPTION
An stream.onchannelclose handler to complement the stream.ondiscoverykey handler.

As a stream-owner i'm using this to detect when channels that were indirectly created - become closed.
```js
const myStream = new Protocol(true, { 
  onchannelclosed: console.log.bind(null, 'channel closed')
})

feed.replicate({ stream: myStream }) // indirect channel created / can't pass my own 'onclose` handler
```
