### PR TITLE
Add live option

### DIFF
--- a/index.js
+++ b/index.js
@@ -261,6 +261,7 @@ module.exports = class ProtocolStream extends Duplex {
     this.handlers = handlers
     this.channelizer = new Channelizer(this, handlers.encrypted, handlers.keyPair)
     this.state = new SHP(initiator, this.channelizer)
+    this.live = !!handlers.live
     this.timeout = null
     this.keepAlive = null
     this.prefinalize = new Nanoguard()
@@ -285,6 +286,7 @@ module.exports = class ProtocolStream extends Duplex {
     return 'HypercoreProtocolStream(\n' +
       indent + '  publicKey: ' + opts.stylize((this.publicKey && pretty(this.publicKey)), 'string') + '\n' +
       indent + '  remotePublicKey: ' + opts.stylize((this.remotePublicKey && pretty(this.remotePublicKey)), 'string') + '\n' +
+      indent + '  live: ' + opts.stylize(this.live, 'boolean') + '\n' +
       indent + '  initiator: ' + opts.stylize(this.initiator, 'boolean') + '\n' +
       indent + '  channelCount: ' + opts.stylize(this.channelCount, 'number') + '\n' +
       indent + '  destroyed: ' + opts.stylize(this.destroyed, 'boolean') + '\n' +
@@ -340,6 +342,7 @@ module.exports = class ProtocolStream extends Duplex {
     this.prefinalize.ready(() => {
       if (this.destroyed) return
       if (this.channelCount) return
+      if (this.live) return
       this.finalize()
     })
   }

--- a/test.js
+++ b/test.js
@@ -450,3 +450,35 @@ tape('can close by discovery key', function (t) {
     t.end()
   })
 })
+
+tape('a live stream does not close', function (t) {
+  const a = new Protocol(true)
+  const b = new Protocol(false, {
+    ondiscoverykey (discoveryKey) {
+      b.close(discoveryKey)
+    }
+  })
+  const c = new Protocol(true, { live: true })
+  const d = new Protocol(false, {
+    live: true,
+    ondiscoverykey (discoveryKey) {
+      d.close(discoveryKey)
+      setTimeout(() => {
+        t.end()
+      }, 500)
+    }
+  })
+
+  a.open(KEY)
+  c.open(KEY)
+
+  a.once('close', () => {
+    t.pass('non-live closed after all channels closed')
+  })
+  d.once('close', () => {
+    t.fail('live should not have closed')
+  })
+
+  a.pipe(b).pipe(a)
+  c.pipe(d).pipe(c)
+})


### PR DESCRIPTION
When a protocol stream is `live`, the stream will not close after all existing channels are closed. This is useful for dynamically adding channels after the initial channel has been closed.