### PR TITLE
(Bug) Opening a bad channel twice prevents stream close

### DIFF
--- a/test.js
+++ b/test.js
@@ -482,3 +482,20 @@ tape('a live stream does not close', function (t) {
   a.pipe(b).pipe(a)
   c.pipe(d).pipe(c)
 })
+
+tape('(bug) immediately reopening a bad channel still closes the stream', function (t) {
+  const a = new Protocol(true)
+  const b = new Protocol(false, {
+    ondiscoverykey (discoveryKey) {
+      b.close(discoveryKey)
+    }
+  })
+
+  a.open(KEY)
+  a.open(KEY)
+
+  a.once('close', () => {
+    t.pass('channel closed')
+    t.end()
+  })
+})


### PR DESCRIPTION
If you open a channel for a bad key (a key that will be immediately rejected by the remote) twice synchronously, the stream will never close.