### PR TITLE
Optionally disable NOISE handshake & capability verification

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ Options include:
 ``` js
 {
   encrypted: true, // set to false to disable encryption if you are already piping through a encrypted stream
-  noise: true, // set to false to disable the NOISE handshake completely. This implies encrypted = false, and also disables the capability verification
+  noise: true, // set to false to disable the NOISE handshake completely. Requires encrypted = false, and also disables the capability verification
   timeout: 20000, // stream timeout. set to 0 or false to disable.
   keyPair: { publicKey, secretKey }, // use this keypair for the stream authentication
   onauthenticate (remotePublicKey, done) { }, // hook to verify the remotes public key

--- a/README.md
+++ b/README.md
@@ -50,6 +50,7 @@ Options include:
 ``` js
 {
   encrypted: true, // set to false to disable encryption if you are already piping through a encrypted stream
+  noise: true, // set to false to disable the NOISE handshake completely. This implies encrypted = false, and also disables the capability verification
   timeout: 20000, // stream timeout. set to 0 or false to disable.
   keyPair: { publicKey, secretKey }, // use this keypair for the stream authentication
   onauthenticate (remotePublicKey, done) { }, // hook to verify the remotes public key

--- a/index.js
+++ b/index.js
@@ -25,7 +25,7 @@ class Channelizer {
     this.created = new Map()
     this.local = [null]
     this.remote = [null]
-    this.noise = noise !== false
+    this.noise = !(noise === false && encrypted === false)
     this.encrypted = encrypted !== false
     this.keyPair = keyPair
   }

--- a/index.js
+++ b/index.js
@@ -20,11 +20,12 @@ class StreamExtension extends Message {
 }
 
 class Channelizer {
-  constructor (stream, encrypted, keyPair) {
+  constructor (stream, { encrypted, noise, keyPair }) {
     this.stream = stream
     this.created = new Map()
     this.local = [null]
     this.remote = [null]
+    this.noise = noise !== false
     this.encrypted = encrypted !== false
     this.keyPair = keyPair
   }
@@ -83,7 +84,7 @@ class Channelizer {
       if (this.stream.handlers.ondiscoverykey) this.stream.handlers.ondiscoverykey(ch.discoveryKey)
       this.stream.emit('discovery-key', ch.discoveryKey)
     } else {
-      if (!ch.remoteVerified) {
+      if (this.noise && !ch.remoteVerified) {
         // We are leaking metadata here that the remote cap was bad which means the remote prob can figure
         // out that we indeed had the key. Since we were the one to initialise the channel that's ok, as
         // that already kinda leaks that.
@@ -312,7 +313,11 @@ module.exports = class ProtocolStream extends Duplex {
 
     this.initiator = initiator
     this.handlers = handlers
-    this.channelizer = new Channelizer(this, handlers.encrypted, handlers.keyPair)
+    this.channelizer = new Channelizer(this, {
+      encrypted: handlers.encrypted,
+      noise: handlers.noise,
+      keyPair: handlers.keyPair
+    })
     this.state = new SHP(initiator, this.channelizer)
     this.live = !!handlers.live
     this.timeout = null

--- a/test.js
+++ b/test.js
@@ -568,9 +568,9 @@ tape('stream extension', function (t) {
   a.pipe(b).pipe(a)
 })
 
-tape.only('disable noise', function (t) {
-  const a = new Protocol(true, { noise: false })
-  const b = new Protocol(false, { noise: false })
+tape('disable noise', function (t) {
+  const a = new Protocol(true, { noise: false, encrypted: false })
+  const b = new Protocol(false, { noise: false, encrypted: false })
 
   const local = a.open(KEY, {
     ondata (data) {

--- a/test.js
+++ b/test.js
@@ -567,3 +567,39 @@ tape('stream extension', function (t) {
 
   a.pipe(b).pipe(a)
 })
+
+tape.only('disable noise', function (t) {
+  const a = new Protocol(true, { noise: false })
+  const b = new Protocol(false, { noise: false })
+
+  const local = a.open(KEY, {
+    ondata (data) {
+      t.same(data.index, 42)
+      t.same(data.value, Buffer.from('value'))
+      t.same(a.publicKey, null)
+      t.same(a.remotePublicKey, null)
+      t.same(b.publicKey, null)
+      t.same(b.remotePublicKey, null)
+      t.end()
+    }
+  })
+
+  const remote = b.open(KEY, {
+    onopen () {
+      t.pass('opened')
+    },
+    onrequest (request) {
+      t.same(request.index, 42)
+      remote.data({
+        index: request.index,
+        value: Buffer.from('value')
+      })
+    }
+  })
+
+  local.request({
+    index: 42
+  })
+
+  a.pipe(b).pipe(a)
+})


### PR DESCRIPTION
This adds an option to disable the NOISE handshake. 

It basically forwards the new setting in [simple-hypercore-protocol #2](https://github.com/mafintosh/simple-hypercore-protocol/pull/2). It also disables the remote verification if opening channels.

See also [hypercore #244](https://github.com/mafintosh/hypercore/pull/244).